### PR TITLE
Add ovirt_repositories_pool var

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Role Variables
 | ovirt_repositories_target_host             | engine                | Type of the target machine, which should be one of [engine, host]. This parameter takes effect only in case <i>ovirt_repositories_use_subscription_manager</i> is set to True. If incorrect version or target is specified no repositories are enabled. |
 | ovirt_repositories_rh_username             | UNDEF                 | Username to use for subscription manager. |
 | ovirt_repositories_rh_password             | UNDEF                 | Password to use for subscription manager. |
-| ovirt_repositories_pool_ids                | UNDEF                 | List of pools ids to subscribe to. If not set the role will consume subscriptions matching `Red Hat Virtualization`. |
+| ovirt_repositories_pool_ids                | UNDEF                 | List of pools ids to subscribe to. |
+| ovirt_repositories_pools                   | UNDEF                 | Specify a list of subscription pool names. Use <i>ovirt_repositories_pool_ids</i> instead if possible, as it is much faster. |
 | ovirt_repositories_repos_backup_path       | /tmp/repo-backup-{{timestamp}} | Directory to backup the original repositories configuration |
 | ovirt_repositories_force_register          | False                 | Bool to register the system even if it is already registered. |
 | ovirt_repositories_rhsm_server_hostname    | UNDEF                 | Hostname of the RHSM server. By default it's used from rhsm configuration. |
@@ -62,6 +63,21 @@ Example Playbook
     ovirt_repositories_pool_ids:
       - 0123456789abcdef0123456789abcdef
       - 1123456789abcdef0123456789abcdef
+
+  roles:
+    - role: oVirt.repositories
+
+
+- name: Setup repositories using Subscription Manager pool name
+  hosts: localhost
+
+  vars:
+    ovirt_repositories_use_subscription_manager: True
+    ovirt_repositories_force_register: True
+    ovirt_repositories_rh_username: "{{ovirt_repositories_rh_username}}"
+    ovirt_repositories_rh_password: "{{ovirt_repositories_rh_password}}"
+    ovirt_repositories_pools:
+      - "Red Hat Cloud Infrastructure, Premium (2-sockets)"
 
   roles:
     - role: oVirt.repositories

--- a/tasks/rh-subscription.yml
+++ b/tasks/rh-subscription.yml
@@ -1,10 +1,24 @@
 ---
+- name: Check if mandatory variables are set
+  fail:
+    msg: "Either ovirt_repositories_pool_ids or ovirt_repositories_pools must be defined."
+  when:
+    - "ovirt_repositories_pool_ids is not defined"
+    - "ovirt_repositories_pools is not defined or ovirt_repositories_pools | list | length == 0"
+
+- name: Check if mandatory variables are set
+  fail:
+    msg: "Both ovirt_repositories_pool_ids and ovirt_repositories_pools can't be defined, only one of them."
+  when:
+    - "ovirt_repositories_pool_ids is defined"
+    - "ovirt_repositories_pools is defined"
+
 - name: Ensure subscription-manager package is installed
   package:
     name: subscription-manager
     state: present
 
-- name: Register and subscribe to multiple pool IDs.
+- name: Register and subscribe to multiple pool IDs
   redhat_subscription:
     state: present
     force_register: "{{ ovirt_repositories_force_register }}"
@@ -12,17 +26,17 @@
     password: "{{ ovirt_repositories_rh_password | mandatory }}"
     pool_ids: "{{ ovirt_repositories_pool_ids }}"
     server_hostname: "{{ ovirt_repositories_rhsm_server_hostname | default(omit) }}"
-  when:  ovirt_repositories_pool_ids is defined
+  when: ovirt_repositories_pool_ids is defined
 
-- name: Use default subscription pool name for Red Hat Virtualization
+- name: Register to and subscribe to pool
   redhat_subscription:
     state: present
     force_register: "{{ ovirt_repositories_force_register }}"
     username: "{{ ovirt_repositories_rh_username | mandatory }}"
     password: "{{ ovirt_repositories_rh_password | mandatory }}"
-    pool: '^Red Hat Virtualization$'
+    pool: "^({{ ovirt_repositories_pools | list | map('regex_escape') | join(')$|^(') }})$"
     server_hostname: "{{ ovirt_repositories_rhsm_server_hostname | default(omit) }}"
-  when:  ovirt_repositories_pool_ids is not defined
+  when: ovirt_repositories_pools is defined
 
 - name: Include target/version specific variables
   include_vars: "{{ item }}"


### PR DESCRIPTION
This variable is used to register and subscribe to pool by subscription
name, instead of using pool ids.

Change-Id: I5461b458d17920be342bdf73ef295831fa3e5ea1
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1548082
Signed-off-by: Ondra Machacek <omachace@redhat.com>