### PR TITLE
ovirt-ansible-repositories: bump ansible to 2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ So you can use any of these names. This documentation and examples in this repos
 Requirements
 ------------
 
- * Ansible version 2.5
+ * Ansible version 2.9
 
 Role Variables
 --------------

--- a/automation.yaml
+++ b/automation.yaml
@@ -1,6 +1,5 @@
 distros:
-  - fc29
   - fc30
   - el7
 release_branches:
-  master: [ "ovirt-master", "ovirt-4.3", "ovirt-4.2" ]
+  master: [ "ovirt-master" ]

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="1.1.6"
+VERSION="1.2.0"
 MILESTONE=master
 RPM_RELEASE="0.1.$MILESTONE.$(date -u +%Y%m%d%H%M%S)"
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
 
   license: Apache License 2.0
 
-  min_ansible_version: 2.5
+  min_ansible_version: 2.9
 
   platforms:
   - name: EL

--- a/ovirt-ansible-repositories.spec.in
+++ b/ovirt-ansible-repositories.spec.in
@@ -13,7 +13,7 @@ Group:          Virtualization/Management
 BuildArch:      noarch
 Url:            http://www.ovirt.org
 
-Requires: ansible >= 2.7.2
+Requires: ansible >= 2.9.0
 
 %description
 This Ansible role is used to set up the repositories required for

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Perform parameter compatibility check
   fail:
     msg: "Subcription manager could be used only on Red Hat Enterprise Linux"
-  when: ovirt_repositories_use_subscription_manager == True and not (ansible_distribution == 'RedHat')
+  when: ovirt_repositories_use_subscription_manager and not (ansible_distribution == 'RedHat')
 
 - name: Backup current repositories
   include_tasks: backup-repos.yml
@@ -14,8 +14,8 @@
 
 - name: Setup repositories using Subscription Manager
   include_tasks: rh-subscription.yml
-  when: ovirt_repositories_use_subscription_manager | bool == True
+  when: ovirt_repositories_use_subscription_manager | bool
 
 - name: Setup repositories using oVirt release package
   include_tasks: rpm.yml
-  when: ovirt_repositories_use_subscription_manager | bool == False
+  when: not ovirt_repositories_use_subscription_manager | bool

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
 ansible-lint
-ansible
+ansible>=2.9.0


### PR DESCRIPTION
Bump ansible to 2.9
- keep only "ovirt-master" in automation.yaml    
- bump project version to 1.2.0 variables need to be registered and then used
- use ansible>=2.9.0 in 
  - ovirt-ansible-repositories.spec.in for build  
  - meta/main.yml for info in ansible galaxy
  - change ansible version in  README.md

https://bugzilla.redhat.com/show_bug.cgi?id=1762259
@machacekondra @mwperina