### PR TITLE
Add ovirt_repositories_clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Role Variables
 | ovirt_repositories_repos_backup_path       | /tmp/repo-backup-{{timestamp}} | Directory to backup the original repositories configuration |
 | ovirt_repositories_force_register          | False                 | Bool to register the system even if it is already registered. |
 | ovirt_repositories_rhsm_server_hostname    | UNDEF                 | Hostname of the RHSM server. By default it's used from rhsm configuration. |
+| ovirt_repositories_clear                   | UNDEF                 | If True all repositories will be unregistred before registering from <i>ovirt_repositories_pool_ids</i>. |
 
 
 Dependencies

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Role Variables
 | ovirt_repositories_repos_backup_path       | /tmp/repo-backup-{{timestamp}} | Directory to backup the original repositories configuration |
 | ovirt_repositories_force_register          | False                 | Bool to register the system even if it is already registered. |
 | ovirt_repositories_rhsm_server_hostname    | UNDEF                 | Hostname of the RHSM server. By default it's used from rhsm configuration. |
-| ovirt_repositories_clear                   | UNDEF                 | If True all repositories will be unregistred before registering from <i>ovirt_repositories_pool_ids</i>. |
+| ovirt_repositories_clear                   | False                 | If True all repositories will be unregistered before registering new ones. |
 
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,6 @@
 ovirt_repositories_repos_backup_path: "/tmp/repo-backup-{{ '%Y-%m-%d-%H:%M:%S' | strftime(ansible_date_time.epoch) }}"
 ovirt_repositories_use_subscription_manager: False
 ovirt_repositories_force_register: False
+ovirt_repositories_clear: False
 ovirt_repositories_ovirt_version: 4.3
 ovirt_repositories_target_host: engine

--- a/tasks/rh-subscription.yml
+++ b/tasks/rh-subscription.yml
@@ -18,12 +18,6 @@
     name: subscription-manager
     state: present
 
-- name: Disable all repositories
-  redhat_subscription:
-    state: absent
-    pool_ids: "*"
-  when: ovirt_repositories_clear is defined and ovirt_repositories_clear
-
 - name: Register and subscribe to multiple pool IDs
   redhat_subscription:
     state: present
@@ -50,6 +44,12 @@
     - "{{ ovirt_repositories_target_host }}_{{ ovirt_repositories_ovirt_version }}.yml"
     - "default.yml"
   when: ovirt_repositories_subscription_manager_repos is not defined
+
+- name: Disable all repositories
+  rhsm_repository:
+    state: absent
+    name: "*"
+  when: ovirt_repositories_clear
 
 - name: Enable required repositories
   rhsm_repository:

--- a/tasks/rh-subscription.yml
+++ b/tasks/rh-subscription.yml
@@ -18,6 +18,12 @@
     name: subscription-manager
     state: present
 
+- name: Disable all repositories
+  redhat_subscription:
+    state: absent
+    pool_ids: "*"
+  when: ovirt_repositories_clear is defined and ovirt_repositories_clear
+
 - name: Register and subscribe to multiple pool IDs
   redhat_subscription:
     state: present


### PR DESCRIPTION
This PR adds parameter `ovirt_repositories_clear` when it is specified on `True` it will remove all registred repositories, before enabeling from `ovirt_repositories_subscription_manager_repos`.
Fixes #40