### PR TITLE
remove redundant checkup condition

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,11 @@
 ---
-- name: Perform parameter compatibility check
+- name: Check if Subscription Manager is about to be used on non RHEL system
   fail:
-    msg: "Subcription manager could be used only on Red Hat Enterprise Linux"
-  when: ovirt_repositories_use_subscription_manager and not (ansible_distribution == 'RedHat')
+    msg: "Subscription manager could be used only on Red Hat Enterprise Linux"
+  when: ovirt_repositories_use_subscription_manager and ansible_distribution != 'RedHat'
 
 - name: Backup current repositories
   include_tasks: backup-repos.yml
-
-- name: Check if Subscription Manager is about to be used on non RHEL system
-  fail:
-    msg: "ovirt_repositories_use_subscription_manager option can be only used on RHEL OS"
-  when: ovirt_repositories_use_subscription_manager and ansible_distribution != "RedHat"
 
 - name: Setup repositories using Subscription Manager
   include_tasks: rh-subscription.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,9 @@
 - name: Check if Subscription Manager is about to be used on non RHEL system
   fail:
     msg: "Subscription manager could be used only on Red Hat Enterprise Linux"
-  when: ovirt_repositories_use_subscription_manager | bool and ansible_distribution != 'RedHat'
+  when:
+    - ovirt_repositories_use_subscription_manager | bool
+    - ansible_distribution != 'RedHat'
 
 - name: Backup current repositories
   include_tasks: backup-repos.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Check if Subscription Manager is about to be used on non RHEL system
   fail:
     msg: "Subscription manager could be used only on Red Hat Enterprise Linux"
-  when: ovirt_repositories_use_subscription_manager and ansible_distribution != 'RedHat'
+  when: ovirt_repositories_use_subscription_manager | bool and ansible_distribution != 'RedHat'
 
 - name: Backup current repositories
   include_tasks: backup-repos.yml


### PR DESCRIPTION
if we will fail on the first condition lines # 2-5:
- name: Perform parameter compatibility check	- name: Check if Subscription Manager is about to be used on non RHEL system
  fail:	  fail:
    msg: "Subcription manager could be used only on Red Hat Enterprise Linux"	    msg: "Subscription manager could be used only on Red Hat Enterprise Linux"
  when: ovirt_repositories_use_subscription_manager and not (ansible_distribution == 'RedHat')	

we never get into the second fail condition lines # 10-13
- name: Check if Subscription Manager is about to be used on non RHEL system	
  fail:	
    msg: "ovirt_repositories_use_subscription_manager option can be only used on RHEL OS"	
  when: ovirt_repositories_use_subscription_manager and ansible_distribution != "RedHat"	

and it looks like the same condition.