### PR TITLE
install modules only when the target host is engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Role Variables
 | ovirt_repositories_ovirt_release_rpm       | UNDEF                 | URL of oVirt release package, which contains required repositories configuration. |
 | ovirt_repositories_use_subscription_manager| False                 | If true it will use repos from subscription manager and the value of <i>ovirt_repositories_ovirt_release_rpm</i> will be ignored. |
 | ovirt_repositories_ovirt_version           | 4.4                   | oVirt release version (Supported versions [4.1, 4.2, 4.3, 4.4]). Will be used to enable the required repositories and enable modules. |
-| ovirt_repositories_target_host             | engine                | Type of the target machine, which should be one of [engine, host, rhvh]. In case <i>ovirt_repositories_use_subscription_manager</i> is set to True. If incorrect version or target is specified no repositories are enabled. |
+| ovirt_repositories_target_host             | engine                | Type of the target machine, which should be one of [engine, host, rhvh]. This parameter takes effect only in case <i>ovirt_repositories_use_subscription_manager</i> is set to True. If incorrect version or target is specified no repositories are enabled. |
 | ovirt_repositories_rh_username             | UNDEF                 | Username to use for subscription manager. |
 | ovirt_repositories_rh_password             | UNDEF                 | Password to use for subscription manager. |
 | ovirt_repositories_pool_ids                | UNDEF                 | List of pools ids to subscribe to. |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Role Variables
 | ovirt_repositories_ovirt_release_rpm       | UNDEF                 | URL of oVirt release package, which contains required repositories configuration. |
 | ovirt_repositories_use_subscription_manager| False                 | If true it will use repos from subscription manager and the value of <i>ovirt_repositories_ovirt_release_rpm</i> will be ignored. |
 | ovirt_repositories_ovirt_version           | 4.4                   | oVirt release version (Supported versions [4.1, 4.2, 4.3, 4.4]). Will be used to enable the required repositories and enable modules. |
-| ovirt_repositories_target_host             | engine                | Type of the target machine, which should be one of [engine, host, rhvh]. This parameter takes effect only in case <i>ovirt_repositories_use_subscription_manager</i> is set to True. If incorrect version or target is specified no repositories are enabled. |
+| ovirt_repositories_target_host             | engine                | Type of the target machine, which should be one of [engine, host, rhvh]. In case <i>ovirt_repositories_use_subscription_manager</i> is set to True. If incorrect version or target is specified no repositories are enabled. |
 | ovirt_repositories_rh_username             | UNDEF                 | Username to use for subscription manager. |
 | ovirt_repositories_rh_password             | UNDEF                 | Password to use for subscription manager. |
 | ovirt_repositories_pool_ids                | UNDEF                 | List of pools ids to subscribe to. |

--- a/tasks/rh-subscription.yml
+++ b/tasks/rh-subscription.yml
@@ -61,4 +61,6 @@
   command: "dnf module enable -y {{ ovirt_repositories_rh_dnf_modules | join(' ') }}"
   args:
     warn: False
-  when: ovirt_repositories_ovirt_version|string >= '4.4'
+  when:
+    - ovirt_repositories_ovirt_version|string >= '4.4'
+    - ovirt_repositories_target_host == 'engine'

--- a/tasks/rpm.yml
+++ b/tasks/rpm.yml
@@ -8,4 +8,6 @@
   command: "dnf module enable -y {{ ovirt_repositories_ovirt_dnf_modules | join(' ') }}"
   args:
     warn: False
-  when: ovirt_repositories_ovirt_version|string >= '4.4'
+  when:
+    - ovirt_repositories_ovirt_version|string >= '4.4'
+    - ovirt_repositories_target_host == 'engine'


### PR DESCRIPTION
we need these modules:
ovirt_repositories_ovirt_dnf_modules: ["pki-deps", "postgresql:12", "javapackages-tools"]
ovirt_repositories_rh_dnf_modules: ["pki-deps", "postgresql:12"]

in the case of an engine machine. 
so it will be better to do it only on the engine.