### PR TITLE
Add option to disable repos backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Role Variables
 | ovirt_repositories_rh_password             | UNDEF                 | Password to use for subscription manager. |
 | ovirt_repositories_pool_ids                | UNDEF                 | List of pools ids to subscribe to. |
 | ovirt_repositories_pools                   | UNDEF                 | Specify a list of subscription pool names. Use <i>ovirt_repositories_pool_ids</i> instead if possible, as it is much faster. |
+| ovirt_repositories_repos_backup            | True                  | When set to `False`, original repositories won't be backed up. |
 | ovirt_repositories_repos_backup_path       | /tmp/repo-backup-{{timestamp}} | Directory to backup the original repositories configuration |
 | ovirt_repositories_force_register          | False                 | Bool to register the system even if it is already registered. |
 | ovirt_repositories_rhsm_server_hostname    | UNDEF                 | Hostname of the RHSM server. By default it's used from rhsm configuration. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+ovirt_repositories_repos_backup: true
 ovirt_repositories_repos_backup_path: "/tmp/repo-backup-{{ '%Y-%m-%d-%H:%M:%S' | strftime(ansible_date_time.epoch) }}"
 ovirt_repositories_use_subscription_manager: False
 ovirt_repositories_force_register: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
 
 - name: Backup current repositories
   include_tasks: backup-repos.yml
+  when: ovirt_repositories_repos_backup
 
 - name: Setup repositories using Subscription Manager
   include_tasks: rh-subscription.yml


### PR DESCRIPTION
Sometimes you don't really need to backup existing repositories. I think this option is worth adding as the backup takes a lot of time for something you might not even want to do. Default behaviour is of course unchanged.