### PR TITLE
add ovirt_repositories_subscription_manager_repos to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Role Variables
 | ovirt_repositories_rh_password             | UNDEF                 | Password to use for subscription manager. |
 | ovirt_repositories_pool_ids                | UNDEF                 | List of pools ids to subscribe to. |
 | ovirt_repositories_pools                   | UNDEF                 | Specify a list of subscription pool names. Use <i>ovirt_repositories_pool_ids</i> instead if possible, as it is much faster. |
+| ovirt_repositories_subscription_manager_repos| []                  | List of repositories to enable by subscription-manager. By default we have list of repositories for each {{ovirt_repositories_target_host}}_{{ovirt_repositories_ovirt_version}} in vars folder. |
 | ovirt_repositories_repos_backup            | True                  | When set to `False`, original repositories won't be backed up. |
 | ovirt_repositories_repos_backup_path       | /tmp/repo-backup-{{timestamp}} | Directory to backup the original repositories configuration |
 | ovirt_repositories_force_register          | False                 | Bool to register the system even if it is already registered. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,5 +6,6 @@ ovirt_repositories_force_register: False
 ovirt_repositories_clear: False
 ovirt_repositories_ovirt_version: 4.4
 ovirt_repositories_target_host: engine
+ovirt_repositories_subscription_manager_repos: []
 ovirt_repositories_ovirt_dnf_modules: ["pki-deps", "postgresql:12", "javapackages-tools"]
 ovirt_repositories_rh_dnf_modules: ["pki-deps", "postgresql:12"]

--- a/tasks/rh-subscription.yml
+++ b/tasks/rh-subscription.yml
@@ -38,12 +38,13 @@
     server_hostname: "{{ ovirt_repositories_rhsm_server_hostname | default(omit) }}"
   when: ovirt_repositories_pools is defined
 
-- name: Include target/version specific variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ovirt_repositories_target_host }}_{{ ovirt_repositories_ovirt_version }}.yml"
-    - "default.yml"
-  when: ovirt_repositories_subscription_manager_repos is not defined
+- debug: var=ovirt_repositories_subscription_manager_repos
+
+- name: "Include {{ ovirt_repositories_target_host }}_{{ ovirt_repositories_ovirt_version }}.yml variables"
+  include_vars: "{{ ovirt_repositories_target_host }}_{{ ovirt_repositories_ovirt_version }}.yml"
+  when: ovirt_repositories_subscription_manager_repos | list | length == 0
+
+- debug: var=ovirt_repositories_subscription_manager_repos
 
 - name: Disable all repositories
   rhsm_repository:
@@ -55,7 +56,7 @@
   rhsm_repository:
     name: "{{ item }}"
     state: "enabled"
-  with_items: "{{ ovirt_repositories_subscription_manager_repos | default([]) }}"
+  with_items: "{{ ovirt_repositories_subscription_manager_repos }}"
 
 - name: Enable dnf modules
   command: "dnf module enable -y {{ ovirt_repositories_rh_dnf_modules | join(' ') }}"
@@ -64,3 +65,6 @@
   when:
     - ovirt_repositories_ovirt_version|string >= '4.4'
     - ovirt_repositories_target_host == 'engine'
+
+- name: set ovirt_repositories_subscription_manager_repos to empty list for the next time
+  include_vars: default.yml

--- a/tasks/rh-subscription.yml
+++ b/tasks/rh-subscription.yml
@@ -38,13 +38,9 @@
     server_hostname: "{{ ovirt_repositories_rhsm_server_hostname | default(omit) }}"
   when: ovirt_repositories_pools is defined
 
-- debug: var=ovirt_repositories_subscription_manager_repos
-
 - name: "Include {{ ovirt_repositories_target_host }}_{{ ovirt_repositories_ovirt_version }}.yml variables"
   include_vars: "{{ ovirt_repositories_target_host }}_{{ ovirt_repositories_ovirt_version }}.yml"
   when: ovirt_repositories_subscription_manager_repos | list | length == 0
-
-- debug: var=ovirt_repositories_subscription_manager_repos
 
 - name: Disable all repositories
   rhsm_repository:


### PR DESCRIPTION
when I run this role twice, the firtst time for host and the second time for engine in the same playbook.
in the first run, we can see that the variable:
ovirt_repositories_subscription_manager_repos is not defined (as expected) 
but in the second time, the variable already defined so the list of ovirt_repositories_subscription_manager_repos
stay as it was.